### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/davehorner/mkcmt/compare/v0.1.0...v0.1.1) - 2025-03-11
+
+### Other
+
+- release v0.1.0
+
 ## [0.1.0](https://github.com/davehorner/mkcmt/releases/tag/v0.1.0) - 2025-03-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "mkcmt"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arboard",
  "clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mkcmt"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["David Horner"]
 description = "mkcmt is make commit.  Conventional Commit Generator"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `mkcmt`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/davehorner/mkcmt/compare/v0.1.0...v0.1.1) - 2025-03-11

### Other

- release v0.1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).