### PR TITLE
v0.2.1, v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/davehorner/mkcmt/compare/v0.2.1...v0.2.2) - 2025-03-12
+
+docs(qc): update README.md addressing version inconsistencies and run HORNERs qc (fmt, fix, audit)
+
+- Updated the README.md to resolve version inconsistencies.
+- Executed HORNERs qc with fmt, fix, and audit options to ensure code quality.
+
 ## [0.2.1](https://github.com/davehorner/mkcmt/compare/v0.2.0...v0.2.1) - 2025-03-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/davehorner/mkcmt/compare/v0.2.0...v0.2.1) - 2025-03-12
+
+### Added
+
+feat(mode_current, mode_recovery, mode_softreset, tests): implement comprehensive branch management enhancements with soft reset (-s), current commit retrieval (-c), and advanced recovery mode integration
+
+- Introduced the -s flag to perform a soft reset on the current branch, preserving uncommitted changes.
+- Added the -c flag to retrieve and display the current last commit message for quick reference.
+- Enhanced recovery mode to seamlessly restore previous commit messages from HEAD@{1}.
+- Developed extensive integration tests to ensure robust functionality across all branch management modes.
+- Begin code for parsing commits and CHANGELOGs
+
+
 ## [0.2.0](https://github.com/davehorner/mkcmt/compare/v0.1.1...v0.2.0) - 2025-03-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "arboard"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +207,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +254,12 @@ checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "core-foundation"
@@ -562,6 +658,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,9 +1077,10 @@ dependencies = [
 
 [[package]]
 name = "mkcmt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arboard",
+ "clap",
  "genai",
  "tokio",
 ]
@@ -1874,6 +1983,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "value-ext"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "mkcmt"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mkcmt"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["David Horner"]
 description = "mkcmt is make commit.  Conventional Commit Generator"
 readme = "README.md"
@@ -16,6 +16,7 @@ edition = "2024"
 [dependencies]
 genai = { version = "0.1.23", optional = true }
 arboard = { version = "3.4.1", optional = true } 
+clap = { version = "4.5.32", features = ["derive"] }
 
 [dependencies.tokio_plain]
 package = "tokio"
@@ -39,44 +40,3 @@ uses_tokio_plain = ["tokio_plain"]
 uses_tokio_rt = ["tokio_rt"]
 arboard = ["dep:arboard"]
 
-# clipboard will be removed in next release.
-# + cargo audit
-#     Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
-#       Loaded 742 security advisories (from /Users/dhorner/.cargo/advisory-db)
-#     Updating crates.io index
-#     Scanning Cargo.lock for vulnerabilities (203 crate dependencies)
-# Crate:     xcb
-# Version:   0.8.2
-# Title:     Multiple soundness issues
-# Date:      2021-02-04
-# ID:        RUSTSEC-2021-0019
-# URL:       https://rustsec.org/advisories/RUSTSEC-2021-0019
-# Solution:  Upgrade to >=1.0
-# Dependency tree:
-# xcb 0.8.2
-# └── x11-clipboard 0.3.3
-#     └── clipboard 0.5.0
-#         └── mkcmt 0.1.0
-#
-# Crate:     clipboard
-# Version:   0.5.0
-# Warning:   unmaintained
-# Title:     clipboard is Unmaintained
-# Date:      2022-06-25
-# ID:        RUSTSEC-2022-0056
-# URL:       https://rustsec.org/advisories/RUSTSEC-2022-0056
-# Dependency tree:
-# clipboard 0.5.0
-# └── mkcmt 0.1.0
-#
-# Crate:     xcb
-# Version:   0.8.2
-# Warning:   unsound
-# Title:     Soundness issue with base::Error
-# Date:      2020-12-10
-# ID:        RUSTSEC-2020-0097
-# URL:       https://rustsec.org/advisories/RUSTSEC-2020-0097
-# Severity:  5.5 (medium)
-#
-# error: 1 vulnerability found!
-# warning: 2 allowed warnings found

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mkcmt"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["David Horner"]
 description = "mkcmt is make commit.  Conventional Commit Generator"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <!-- Version notice -->
 <p style="font-style: italic; color: #ccc; margin-top: 0.5em;">
-  You are reading documentation version <span id="doc-version" style="color: white;">0.2.0</span>.
+  You are reading documentation version <span id="doc-version" style="color: white;">0.2.2</span>.
   If this does not match the version displayed above, then you're not reading the latest documentation!
 </p>
 
@@ -80,7 +80,7 @@ Options:
   - If declined, GPT is used iteratively to refine the prompt until an acceptable commit message is produced.
 
 _The iterative refinement and nice initial prompts are TBD (To Be Developed).  What you get now might not be as good as `giff diff --cached | (clip|pbcopy)` taken straight to consumer
-ChatGPT interface.  This is v0.2.1; expect simple._
+ChatGPT interface.  This is v0.2.2; expect simple._
 
 ## Output Logs
 
@@ -144,6 +144,6 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 <!-- Version notice -->
 <p style="font-style: italic; color: #ccc; margin-top: 0.5em;">
-  You are reading documentation version <span id="doc-version" style="color: white;">0.2.0</span>.
+  You are reading documentation version <span id="doc-version" style="color: white;">0.2.2</span>.
   If this does not match the version displayed above, then you're not reading the latest documentation!
 </p>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ This tool generates concise or lengthy, Conventional Commit-compatible commit me
 - **Intelligent Commit Message Generation:** Leverages AI to analyze Git diffs and generate clear, descriptive commit messages.
 - **Interactive Refinement:** If the initial suggestion isn't suitable, the tool progressively refines the prompt to generate better commit messages.
 - **Clipboard Integration:** Offers the convenience of copying commit messages directly to the clipboard.
+- **Recovery Mode:** Use the `-r` or `--recovery` flag to extract the previous commit message from `HEAD@{1}` and copy it directly to your system clipboard.
+- **Soft Reset Mode:** Use the `-s` or `--soft-reset` flag to perform a soft reset on the current branch, enabling you to amend the last commit without losing changes.
+- **Display Current Commit:** Use the `-c` or `--current` flag to display the current (last) commit message for review.
 - **Detailed Logging:** Maintains logs of both generated commit messages and refined prompts for easy reference.
 
 ## Installation
@@ -53,6 +56,19 @@ export OPENAI_API_KEY="your-api-key-here"
 
 run mkcmt in a git folder with some changes.  follow the prompts.
 
+```
+mkcmt -h
+mkcmt is make commit.  Conventional Commit Generator
+
+Usage: mkcmt [OPTIONS]
+
+Options:
+  -r, --recovery    Activate recovery mode to restore a previous commit message (from HEAD@{1})
+  -s, --soft-reset  Perform a soft reset on the current branch
+  -c, --current     Display the current (last) commit message
+  -h, --help        Print help
+  -V, --version     Print version
+```
 
 ### Workflow:
 
@@ -62,6 +78,9 @@ run mkcmt in a git folder with some changes.  follow the prompts.
 - Presents the commit message and prompts for acceptance.
   - If accepted, optionally copies it to the clipboard.
   - If declined, GPT is used iteratively to refine the prompt until an acceptable commit message is produced.
+
+_The iterative refinement and nice initial prompts are TBD (To Be Developed).  What you get now might not be as good as `giff diff --cached | (clip|pbcopy)` taken straight to consumer
+ChatGPT interface.  This is v0.2.1; expect simple._
 
 ## Output Logs
 
@@ -109,6 +128,11 @@ Accept this commit message? (y/n): y
 Copy commit message to clipboard? (y/n): y
 Commit message copied to clipboard.
 ```
+
+### Commit Message Recovery Note
+
+When developing a new feature, it is essential to adhere to conventional commit standards. I employ `mkcmt` to ensure that commit messages conform to these conventions. However, there are instances where it becomes necessary to undo a commit generated for `release-plz update`—for example, when modifications to the CHANGELOG or other adjustments are required. In such cases, the originally intended commit message may be lost. The recovery mode in `mkcmt` (activated with the `-r` flag) facilitates the restoration of this commit message from `HEAD@{1}` by copying it to the clipboard, thereby preserving the original message for future use.
+
 
 ## License
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -12,14 +12,7 @@ pub const TYPES: &[&str] = &[
 ];
 
 /// Allowed scopes (e.g., modules or subsystems).
-pub const SCOPES: &[&str] = &[
-    "core",
-    "ui",
-    "api",
-    "build",
-    "docs",
-    "tests",
-];
+pub const SCOPES: &[&str] = &["core", "ui", "api", "build", "docs", "tests"];
 
 /// Marker that indicates a breaking change in the commit message footer.
 pub const BREAKING_CHANGE_MARKER: &str = "!";
@@ -53,4 +46,3 @@ mod tests {
         assert_eq!(changelog.breaking_marker, "!");
     }
 }
-

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,0 +1,56 @@
+/// The `changelog` module contains metadata about commit types, scopes, and the breaking change marker.
+
+/// Allowed commit types.
+pub const TYPES: &[&str] = &[
+    "feat",     // new features
+    "fix",      // bug fixes
+    "docs",     // documentation only changes
+    "style",    // formatting and style changes
+    "refactor", // code refactoring
+    "test",     // tests additions or fixes
+    "chore",    // maintenance tasks
+];
+
+/// Allowed scopes (e.g., modules or subsystems).
+pub const SCOPES: &[&str] = &[
+    "core",
+    "ui",
+    "api",
+    "build",
+    "docs",
+    "tests",
+];
+
+/// Marker that indicates a breaking change in the commit message footer.
+pub const BREAKING_CHANGE_MARKER: &str = "!";
+
+/// A structure representing the complete changelog metadata.
+#[derive(Debug)]
+pub struct Changelog {
+    pub types: &'static [&'static str],
+    pub scopes: &'static [&'static str],
+    pub breaking_marker: &'static str,
+}
+
+/// Returns the changelog metadata.
+pub fn get_changelog() -> Changelog {
+    Changelog {
+        types: TYPES,
+        scopes: SCOPES,
+        breaking_marker: BREAKING_CHANGE_MARKER,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_changelog_contents() {
+        let changelog = get_changelog();
+        assert!(changelog.types.contains(&"feat"));
+        assert!(changelog.scopes.contains(&"ui"));
+        assert_eq!(changelog.breaking_marker, "!");
+    }
+}
+

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,0 +1,299 @@
+//! # Conventional Commit Parser and Changelog
+//!
+//! This library provides a parser for conventional commit messages. The expected commit
+//! format is:
+//!
+//! ```text
+//! <type>(<optional scope>): <description>
+//! 
+//! <optional body>
+//! 
+//! <optional footer>
+//! ```
+//!
+//! It also exposes a changelog module that models allowed commit types, scopes,
+//! and identifies breaking changes using the "!" marker.
+
+/// The commit module contains types and parsing functionality for conventional commits.
+    /// Represents a conventional commit message.
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct CommitMessage {
+        /// The commit type (e.g., "feat", "fix").
+        pub commit_type: String,
+        /// The optional scope (e.g., "ui", "api").
+        pub scope: Option<String>,
+        /// The commit description.
+        pub description: String,
+        /// The optional body of the commit message.
+        pub body: Option<String>,
+        /// The optional footer of the commit message.
+        pub footer: Option<String>,
+        /// Whether this commit includes breaking changes.
+        pub breaking: bool,
+    }
+
+    impl CommitMessage {
+        /// Parses a conventional commit message from a given input string.
+        ///
+        /// The parser expects the following structure:
+        /// 1. A header line formatted as `<type>(<optional scope>): <description>`
+        /// 2. A blank line
+        /// 3. An optional body
+        /// 4. A blank line
+        /// 5. An optional footer (where a "!" in the footer indicates breaking changes)
+        ///
+        /// # Examples
+        ///
+        ///
+        /// This example is expected to fail because the footer does not include the '!' required
+        /// to mark the commit as breaking. In this case, `commit.breaking` remains `false`.
+        /// ```rust,should_panic
+        /// use mkcmt::commit::CommitMessage;
+        ///
+        /// let input = "feat(ui): add new button\n\nThis commit adds a new button to the UI.\n\nBREAKING CHANGE: The button API has changed.";
+        /// let commit = CommitMessage::parse(input).unwrap();
+        /// assert_eq!(commit.commit_type, "feat");
+        /// assert_eq!(commit.scope, Some("ui".into()));
+        /// // The following assertion fails because the footer is missing an exclamation mark,
+        /// // so `commit.breaking` remains false instead of true.
+        /// assert!(commit.breaking);
+        /// ```
+        /// 
+        /// 
+        /// 
+        /// Parses a conventional commit message from a given input string.
+///
+/// The parser expects the following structure:
+/// 1. A header line formatted as `<type>(<optional scope>): <description>`
+/// 2. A blank line
+/// 3. An optional body
+/// 4. A blank line
+/// 5. An optional footer (where a "!" in the footer indicates breaking changes)
+///
+/// # Examples
+///
+/// This example is expected to fail because the footer does not include the '!' required
+/// to mark the commit as breaking. In this case, `commit.breaking` remains `false`.
+/// ```rust,should_panic
+/// use mkcmt::commit::CommitMessage;
+///
+/// let input = "feat(ui): add new button\n\nThis commit adds a new button to the UI.\n\nBREAKING CHANGE: The button API has changed.";
+/// let commit = CommitMessage::parse(input).unwrap();
+/// assert_eq!(commit.commit_type, "feat");
+/// assert_eq!(commit.scope, Some("ui".into()));
+/// // The following assertion fails because the footer is missing an exclamation mark,
+/// // so `commit.breaking` remains false instead of true.
+/// assert!(commit.breaking);
+/// ```
+/// Parses a conventional commit message from a given input string.
+///
+/// The expected format is:
+///
+/// ```text
+/// <type>(<optional scope>): <description>
+///
+/// <optional body>
+///
+/// <optional footer>
+/// ```
+///
+/// A footer containing the breaking change marker (an exclamation mark `!`) indicates a breaking change.
+///
+/// # Examples
+///
+/// Proper formatting with blank lines (breaking change detected):
+/// ```rust
+        /// use mkcmt::commit::CommitMessage;
+///
+/// let input = r#"feat(ui): add new button
+///
+/// This commit adds a new button to the UI.
+///
+/// BREAKING CHANGE!: The button API has changed."#;
+///
+/// let commit = CommitMessage::parse(input).unwrap();
+/// assert!(commit.breaking, "Expected commit to be marked as breaking");
+/// ```
+///
+/// Missing blank lines between sections (no breaking change detected):
+/// ```rust
+/// use mkcmt::commit::CommitMessage;
+///
+/// let input = "feat(ui): add new button\nThis commit adds a new button to the UI.\nBREAKING CHANGE!: The button API has changed.";
+///
+/// let commit = CommitMessage::parse(input).unwrap();
+/// // Without proper blank lines, the input is treated as a single header, so no footer is detected.
+/// assert!(!commit.breaking, "Expected commit not to be marked as breaking");
+/// ```
+        pub fn parse(input: &str) -> Result<Self, String> {
+            // Split into sections using double newlines to separate header, body, and footer.
+            let parts: Vec<&str> = input.split("\n\n").collect();
+
+            if parts.is_empty() {
+                return Err("Empty commit message".to_string());
+            }
+
+            // Parse header: expecting `<type>(<optional scope>): <description>`
+            let header = parts[0].trim();
+            let (commit_type, scope, description) = Self::parse_header(header)?;
+
+            // Parse optional body (if present)
+            let body = if parts.len() > 1 && !parts[1].trim().is_empty() {
+                Some(parts[1].trim().to_string())
+            } else {
+                None
+            };
+
+            // Parse optional footer (if present) and check for breaking changes
+            let (footer, breaking) = if parts.len() > 2 && !parts[2].trim().is_empty() {
+                let footer_text = parts[2].trim().to_string();
+                let is_breaking = footer_text.contains('!');
+                (Some(footer_text), is_breaking)
+            } else {
+                (None, false)
+            };
+
+            Ok(CommitMessage {
+                commit_type,
+                scope,
+                description,
+                body,
+                footer,
+                breaking,
+            })
+        }
+
+        /// Helper function to parse the header line.
+        ///
+        /// Returns a tuple of (commit_type, scope, description).
+        fn parse_header(header: &str) -> Result<(String, Option<String>, String), String> {
+            // Find the first colon that separates the header.
+            let colon_index = header.find(':').ok_or("Missing ':' in header")?;
+            let (meta, description) = header.split_at(colon_index);
+            let description = description[1..].trim(); // skip the colon
+
+            // Check if there's an optional scope (enclosed in parentheses)
+            if let Some(start) = meta.find('(') {
+                let end = meta.find(')').ok_or("Missing closing ')' in header")?;
+                let commit_type = meta[..start].trim().to_string();
+                let scope = meta[start + 1..end].trim().to_string();
+                if scope.is_empty() {
+                    return Err("Empty scope in header".into());
+                }
+                Ok((commit_type, Some(scope), description.to_string()))
+            } else {
+                // No scope provided.
+                Ok((meta.trim().to_string(), None, description.to_string()))
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_parse_with_scope_and_footer_breaking() {
+            let input = "\
+feat(ui): add new button
+
+This commit adds a new button to the UI.
+
+BREAKING CHANGE!: The button API has changed.";
+            let commit = CommitMessage::parse(input).unwrap();
+            assert_eq!(commit.commit_type, "feat");
+            assert_eq!(commit.scope, Some("ui".into()));
+            assert_eq!(commit.description, "add new button");
+            assert_eq!(commit.body, Some("This commit adds a new button to the UI.".into()));
+            assert!(commit.breaking);
+        }
+
+        #[test]
+        fn test_parse_without_scope_and_footer() {
+            let input = "fix: correct typo";
+            let commit = CommitMessage::parse(input).unwrap();
+            assert_eq!(commit.commit_type, "fix");
+            assert_eq!(commit.scope, None);
+            assert_eq!(commit.description, "correct typo");
+            assert_eq!(commit.body, None);
+            assert_eq!(commit.footer, None);
+            assert!(!commit.breaking);
+        }
+
+        #[test]
+        fn test_parse_with_empty_body_and_footer() {
+            let input = "docs(api): update documentation\n\n\n";
+            let commit = CommitMessage::parse(input).unwrap();
+            assert_eq!(commit.commit_type, "docs");
+            assert_eq!(commit.scope, Some("api".into()));
+            assert_eq!(commit.description, "update documentation");
+            assert_eq!(commit.body, None);
+            assert_eq!(commit.footer, None);
+            assert!(!commit.breaking);
+        }
+
+        #[test]
+        fn test_parse_error_missing_colon() {
+            let input = "chore update dependencies";
+            let err = CommitMessage::parse(input).unwrap_err();
+            assert!(err.contains("Missing ':'"));
+        }
+    }
+
+/// The changelog module contains data about allowed commit types, scopes, and the breaking change marker.
+pub mod changelog {
+    /// List of allowed commit types.
+    pub const TYPES: &[&str] = &[
+        "feat",   // new features
+        "fix",    // bug fixes
+        "docs",   // documentation only changes
+        "style",  // code style changes (formatting, etc.)
+        "refactor", // code refactoring
+        "test",   // adding missing tests or correcting existing tests
+        "chore",  // changes to the build process or auxiliary tools and libraries
+    ];
+
+    /// List of allowed scopes. These could be modules, subsystems, or components.
+    pub const SCOPES: &[&str] = &[
+        "core",
+        "ui",
+        "api",
+        "build",
+        "docs",
+        "tests",
+    ];
+
+    /// Marker that indicates a breaking change in the commit message footer.
+    pub const BREAKING_CHANGE_MARKER: &str = "!";
+
+    /// Represents the complete changelog metadata.
+    #[derive(Debug)]
+    pub struct Changelog {
+        pub types: &'static [&'static str],
+        pub scopes: &'static [&'static str],
+        pub breaking_marker: &'static str,
+    }
+
+    /// Returns the changelog metadata.
+    pub fn get_changelog() -> Changelog {
+        Changelog {
+            types: TYPES,
+            scopes: SCOPES,
+            breaking_marker: BREAKING_CHANGE_MARKER,
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_changelog_contents() {
+            let changelog = get_changelog();
+            assert!(changelog.types.contains(&"feat"));
+            assert!(changelog.scopes.contains(&"ui"));
+            assert_eq!(changelog.breaking_marker, "!");
+        }
+    }
+}
+

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -5,9 +5,9 @@
 //!
 //! ```text
 //! <type>(<optional scope>): <description>
-//! 
+//!
 //! <optional body>
-//! 
+//!
 //! <optional footer>
 //! ```
 //!
@@ -15,253 +15,249 @@
 //! and identifies breaking changes using the "!" marker.
 
 /// The commit module contains types and parsing functionality for conventional commits.
-    /// Represents a conventional commit message.
-    #[derive(Debug, PartialEq, Eq)]
-    pub struct CommitMessage {
-        /// The commit type (e.g., "feat", "fix").
-        pub commit_type: String,
-        /// The optional scope (e.g., "ui", "api").
-        pub scope: Option<String>,
-        /// The commit description.
-        pub description: String,
-        /// The optional body of the commit message.
-        pub body: Option<String>,
-        /// The optional footer of the commit message.
-        pub footer: Option<String>,
-        /// Whether this commit includes breaking changes.
-        pub breaking: bool,
-    }
+/// Represents a conventional commit message.
+#[derive(Debug, PartialEq, Eq)]
+pub struct CommitMessage {
+    /// The commit type (e.g., "feat", "fix").
+    pub commit_type: String,
+    /// The optional scope (e.g., "ui", "api").
+    pub scope: Option<String>,
+    /// The commit description.
+    pub description: String,
+    /// The optional body of the commit message.
+    pub body: Option<String>,
+    /// The optional footer of the commit message.
+    pub footer: Option<String>,
+    /// Whether this commit includes breaking changes.
+    pub breaking: bool,
+}
 
-    impl CommitMessage {
-        /// Parses a conventional commit message from a given input string.
-        ///
-        /// The parser expects the following structure:
-        /// 1. A header line formatted as `<type>(<optional scope>): <description>`
-        /// 2. A blank line
-        /// 3. An optional body
-        /// 4. A blank line
-        /// 5. An optional footer (where a "!" in the footer indicates breaking changes)
-        ///
-        /// # Examples
-        ///
-        ///
-        /// This example is expected to fail because the footer does not include the '!' required
-        /// to mark the commit as breaking. In this case, `commit.breaking` remains `false`.
-        /// ```rust,should_panic
-        /// use mkcmt::commit::CommitMessage;
-        ///
-        /// let input = "feat(ui): add new button\n\nThis commit adds a new button to the UI.\n\nBREAKING CHANGE: The button API has changed.";
-        /// let commit = CommitMessage::parse(input).unwrap();
-        /// assert_eq!(commit.commit_type, "feat");
-        /// assert_eq!(commit.scope, Some("ui".into()));
-        /// // The following assertion fails because the footer is missing an exclamation mark,
-        /// // so `commit.breaking` remains false instead of true.
-        /// assert!(commit.breaking);
-        /// ```
-        /// 
-        /// 
-        /// 
-        /// Parses a conventional commit message from a given input string.
-///
-/// The parser expects the following structure:
-/// 1. A header line formatted as `<type>(<optional scope>): <description>`
-/// 2. A blank line
-/// 3. An optional body
-/// 4. A blank line
-/// 5. An optional footer (where a "!" in the footer indicates breaking changes)
-///
-/// # Examples
-///
-/// This example is expected to fail because the footer does not include the '!' required
-/// to mark the commit as breaking. In this case, `commit.breaking` remains `false`.
-/// ```rust,should_panic
-/// use mkcmt::commit::CommitMessage;
-///
-/// let input = "feat(ui): add new button\n\nThis commit adds a new button to the UI.\n\nBREAKING CHANGE: The button API has changed.";
-/// let commit = CommitMessage::parse(input).unwrap();
-/// assert_eq!(commit.commit_type, "feat");
-/// assert_eq!(commit.scope, Some("ui".into()));
-/// // The following assertion fails because the footer is missing an exclamation mark,
-/// // so `commit.breaking` remains false instead of true.
-/// assert!(commit.breaking);
-/// ```
-/// Parses a conventional commit message from a given input string.
-///
-/// The expected format is:
-///
-/// ```text
-/// <type>(<optional scope>): <description>
-///
-/// <optional body>
-///
-/// <optional footer>
-/// ```
-///
-/// A footer containing the breaking change marker (an exclamation mark `!`) indicates a breaking change.
-///
-/// # Examples
-///
-/// Proper formatting with blank lines (breaking change detected):
-/// ```rust
-        /// use mkcmt::commit::CommitMessage;
-///
-/// let input = r#"feat(ui): add new button
-///
-/// This commit adds a new button to the UI.
-///
-/// BREAKING CHANGE!: The button API has changed."#;
-///
-/// let commit = CommitMessage::parse(input).unwrap();
-/// assert!(commit.breaking, "Expected commit to be marked as breaking");
-/// ```
-///
-/// Missing blank lines between sections (no breaking change detected):
-/// ```rust
-/// use mkcmt::commit::CommitMessage;
-///
-/// let input = "feat(ui): add new button\nThis commit adds a new button to the UI.\nBREAKING CHANGE!: The button API has changed.";
-///
-/// let commit = CommitMessage::parse(input).unwrap();
-/// // Without proper blank lines, the input is treated as a single header, so no footer is detected.
-/// assert!(!commit.breaking, "Expected commit not to be marked as breaking");
-/// ```
-        pub fn parse(input: &str) -> Result<Self, String> {
-            // Split into sections using double newlines to separate header, body, and footer.
-            let parts: Vec<&str> = input.split("\n\n").collect();
+impl CommitMessage {
+    /// Parses a conventional commit message from a given input string.
+    ///
+    /// The parser expects the following structure:
+    /// 1. A header line formatted as `<type>(<optional scope>): <description>`
+    /// 2. A blank line
+    /// 3. An optional body
+    /// 4. A blank line
+    /// 5. An optional footer (where a "!" in the footer indicates breaking changes)
+    ///
+    /// # Examples
+    ///
+    ///
+    /// This example is expected to fail because the footer does not include the '!' required
+    /// to mark the commit as breaking. In this case, `commit.breaking` remains `false`.
+    /// ```rust,should_panic
+    /// use mkcmt::commit::CommitMessage;
+    ///
+    /// let input = "feat(ui): add new button\n\nThis commit adds a new button to the UI.\n\nBREAKING CHANGE: The button API has changed.";
+    /// let commit = CommitMessage::parse(input).unwrap();
+    /// assert_eq!(commit.commit_type, "feat");
+    /// assert_eq!(commit.scope, Some("ui".into()));
+    /// // The following assertion fails because the footer is missing an exclamation mark,
+    /// // so `commit.breaking` remains false instead of true.
+    /// assert!(commit.breaking);
+    /// ```
+    ///
+    ///
+    ///
+    /// Parses a conventional commit message from a given input string.
+    ///
+    /// The parser expects the following structure:
+    /// 1. A header line formatted as `<type>(<optional scope>): <description>`
+    /// 2. A blank line
+    /// 3. An optional body
+    /// 4. A blank line
+    /// 5. An optional footer (where a "!" in the footer indicates breaking changes)
+    ///
+    /// # Examples
+    ///
+    /// This example is expected to fail because the footer does not include the '!' required
+    /// to mark the commit as breaking. In this case, `commit.breaking` remains `false`.
+    /// ```rust,should_panic
+    /// use mkcmt::commit::CommitMessage;
+    ///
+    /// let input = "feat(ui): add new button\n\nThis commit adds a new button to the UI.\n\nBREAKING CHANGE: The button API has changed.";
+    /// let commit = CommitMessage::parse(input).unwrap();
+    /// assert_eq!(commit.commit_type, "feat");
+    /// assert_eq!(commit.scope, Some("ui".into()));
+    /// // The following assertion fails because the footer is missing an exclamation mark,
+    /// // so `commit.breaking` remains false instead of true.
+    /// assert!(commit.breaking);
+    /// ```
+    /// Parses a conventional commit message from a given input string.
+    ///
+    /// The expected format is:
+    ///
+    /// ```text
+    /// <type>(<optional scope>): <description>
+    ///
+    /// <optional body>
+    ///
+    /// <optional footer>
+    /// ```
+    ///
+    /// A footer containing the breaking change marker (an exclamation mark `!`) indicates a breaking change.
+    ///
+    /// # Examples
+    ///
+    /// Proper formatting with blank lines (breaking change detected):
+    /// ```rust
+    /// use mkcmt::commit::CommitMessage;
+    ///
+    /// let input = r#"feat(ui): add new button
+    ///
+    /// This commit adds a new button to the UI.
+    ///
+    /// BREAKING CHANGE!: The button API has changed."#;
+    ///
+    /// let commit = CommitMessage::parse(input).unwrap();
+    /// assert!(commit.breaking, "Expected commit to be marked as breaking");
+    /// ```
+    ///
+    /// Missing blank lines between sections (no breaking change detected):
+    /// ```rust
+    /// use mkcmt::commit::CommitMessage;
+    ///
+    /// let input = "feat(ui): add new button\nThis commit adds a new button to the UI.\nBREAKING CHANGE!: The button API has changed.";
+    ///
+    /// let commit = CommitMessage::parse(input).unwrap();
+    /// // Without proper blank lines, the input is treated as a single header, so no footer is detected.
+    /// assert!(!commit.breaking, "Expected commit not to be marked as breaking");
+    /// ```
+    pub fn parse(input: &str) -> Result<Self, String> {
+        // Split into sections using double newlines to separate header, body, and footer.
+        let parts: Vec<&str> = input.split("\n\n").collect();
 
-            if parts.is_empty() {
-                return Err("Empty commit message".to_string());
-            }
-
-            // Parse header: expecting `<type>(<optional scope>): <description>`
-            let header = parts[0].trim();
-            let (commit_type, scope, description) = Self::parse_header(header)?;
-
-            // Parse optional body (if present)
-            let body = if parts.len() > 1 && !parts[1].trim().is_empty() {
-                Some(parts[1].trim().to_string())
-            } else {
-                None
-            };
-
-            // Parse optional footer (if present) and check for breaking changes
-            let (footer, breaking) = if parts.len() > 2 && !parts[2].trim().is_empty() {
-                let footer_text = parts[2].trim().to_string();
-                let is_breaking = footer_text.contains('!');
-                (Some(footer_text), is_breaking)
-            } else {
-                (None, false)
-            };
-
-            Ok(CommitMessage {
-                commit_type,
-                scope,
-                description,
-                body,
-                footer,
-                breaking,
-            })
+        if parts.is_empty() {
+            return Err("Empty commit message".to_string());
         }
 
-        /// Helper function to parse the header line.
-        ///
-        /// Returns a tuple of (commit_type, scope, description).
-        fn parse_header(header: &str) -> Result<(String, Option<String>, String), String> {
-            // Find the first colon that separates the header.
-            let colon_index = header.find(':').ok_or("Missing ':' in header")?;
-            let (meta, description) = header.split_at(colon_index);
-            let description = description[1..].trim(); // skip the colon
+        // Parse header: expecting `<type>(<optional scope>): <description>`
+        let header = parts[0].trim();
+        let (commit_type, scope, description) = Self::parse_header(header)?;
 
-            // Check if there's an optional scope (enclosed in parentheses)
-            if let Some(start) = meta.find('(') {
-                let end = meta.find(')').ok_or("Missing closing ')' in header")?;
-                let commit_type = meta[..start].trim().to_string();
-                let scope = meta[start + 1..end].trim().to_string();
-                if scope.is_empty() {
-                    return Err("Empty scope in header".into());
-                }
-                Ok((commit_type, Some(scope), description.to_string()))
-            } else {
-                // No scope provided.
-                Ok((meta.trim().to_string(), None, description.to_string()))
-            }
-        }
+        // Parse optional body (if present)
+        let body = if parts.len() > 1 && !parts[1].trim().is_empty() {
+            Some(parts[1].trim().to_string())
+        } else {
+            None
+        };
+
+        // Parse optional footer (if present) and check for breaking changes
+        let (footer, breaking) = if parts.len() > 2 && !parts[2].trim().is_empty() {
+            let footer_text = parts[2].trim().to_string();
+            let is_breaking = footer_text.contains('!');
+            (Some(footer_text), is_breaking)
+        } else {
+            (None, false)
+        };
+
+        Ok(CommitMessage {
+            commit_type,
+            scope,
+            description,
+            body,
+            footer,
+            breaking,
+        })
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
+    /// Helper function to parse the header line.
+    ///
+    /// Returns a tuple of (commit_type, scope, description).
+    fn parse_header(header: &str) -> Result<(String, Option<String>, String), String> {
+        // Find the first colon that separates the header.
+        let colon_index = header.find(':').ok_or("Missing ':' in header")?;
+        let (meta, description) = header.split_at(colon_index);
+        let description = description[1..].trim(); // skip the colon
 
-        #[test]
-        fn test_parse_with_scope_and_footer_breaking() {
-            let input = "\
+        // Check if there's an optional scope (enclosed in parentheses)
+        if let Some(start) = meta.find('(') {
+            let end = meta.find(')').ok_or("Missing closing ')' in header")?;
+            let commit_type = meta[..start].trim().to_string();
+            let scope = meta[start + 1..end].trim().to_string();
+            if scope.is_empty() {
+                return Err("Empty scope in header".into());
+            }
+            Ok((commit_type, Some(scope), description.to_string()))
+        } else {
+            // No scope provided.
+            Ok((meta.trim().to_string(), None, description.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_with_scope_and_footer_breaking() {
+        let input = "\
 feat(ui): add new button
 
 This commit adds a new button to the UI.
 
 BREAKING CHANGE!: The button API has changed.";
-            let commit = CommitMessage::parse(input).unwrap();
-            assert_eq!(commit.commit_type, "feat");
-            assert_eq!(commit.scope, Some("ui".into()));
-            assert_eq!(commit.description, "add new button");
-            assert_eq!(commit.body, Some("This commit adds a new button to the UI.".into()));
-            assert!(commit.breaking);
-        }
-
-        #[test]
-        fn test_parse_without_scope_and_footer() {
-            let input = "fix: correct typo";
-            let commit = CommitMessage::parse(input).unwrap();
-            assert_eq!(commit.commit_type, "fix");
-            assert_eq!(commit.scope, None);
-            assert_eq!(commit.description, "correct typo");
-            assert_eq!(commit.body, None);
-            assert_eq!(commit.footer, None);
-            assert!(!commit.breaking);
-        }
-
-        #[test]
-        fn test_parse_with_empty_body_and_footer() {
-            let input = "docs(api): update documentation\n\n\n";
-            let commit = CommitMessage::parse(input).unwrap();
-            assert_eq!(commit.commit_type, "docs");
-            assert_eq!(commit.scope, Some("api".into()));
-            assert_eq!(commit.description, "update documentation");
-            assert_eq!(commit.body, None);
-            assert_eq!(commit.footer, None);
-            assert!(!commit.breaking);
-        }
-
-        #[test]
-        fn test_parse_error_missing_colon() {
-            let input = "chore update dependencies";
-            let err = CommitMessage::parse(input).unwrap_err();
-            assert!(err.contains("Missing ':'"));
-        }
+        let commit = CommitMessage::parse(input).unwrap();
+        assert_eq!(commit.commit_type, "feat");
+        assert_eq!(commit.scope, Some("ui".into()));
+        assert_eq!(commit.description, "add new button");
+        assert_eq!(
+            commit.body,
+            Some("This commit adds a new button to the UI.".into())
+        );
+        assert!(commit.breaking);
     }
+
+    #[test]
+    fn test_parse_without_scope_and_footer() {
+        let input = "fix: correct typo";
+        let commit = CommitMessage::parse(input).unwrap();
+        assert_eq!(commit.commit_type, "fix");
+        assert_eq!(commit.scope, None);
+        assert_eq!(commit.description, "correct typo");
+        assert_eq!(commit.body, None);
+        assert_eq!(commit.footer, None);
+        assert!(!commit.breaking);
+    }
+
+    #[test]
+    fn test_parse_with_empty_body_and_footer() {
+        let input = "docs(api): update documentation\n\n\n";
+        let commit = CommitMessage::parse(input).unwrap();
+        assert_eq!(commit.commit_type, "docs");
+        assert_eq!(commit.scope, Some("api".into()));
+        assert_eq!(commit.description, "update documentation");
+        assert_eq!(commit.body, None);
+        assert_eq!(commit.footer, None);
+        assert!(!commit.breaking);
+    }
+
+    #[test]
+    fn test_parse_error_missing_colon() {
+        let input = "chore update dependencies";
+        let err = CommitMessage::parse(input).unwrap_err();
+        assert!(err.contains("Missing ':'"));
+    }
+}
 
 /// The changelog module contains data about allowed commit types, scopes, and the breaking change marker.
 pub mod changelog {
     /// List of allowed commit types.
     pub const TYPES: &[&str] = &[
-        "feat",   // new features
-        "fix",    // bug fixes
-        "docs",   // documentation only changes
-        "style",  // code style changes (formatting, etc.)
+        "feat",     // new features
+        "fix",      // bug fixes
+        "docs",     // documentation only changes
+        "style",    // code style changes (formatting, etc.)
         "refactor", // code refactoring
-        "test",   // adding missing tests or correcting existing tests
-        "chore",  // changes to the build process or auxiliary tools and libraries
+        "test",     // adding missing tests or correcting existing tests
+        "chore",    // changes to the build process or auxiliary tools and libraries
     ];
 
     /// List of allowed scopes. These could be modules, subsystems, or components.
-    pub const SCOPES: &[&str] = &[
-        "core",
-        "ui",
-        "api",
-        "build",
-        "docs",
-        "tests",
-    ];
+    pub const SCOPES: &[&str] = &["core", "ui", "api", "build", "docs", "tests"];
 
     /// Marker that indicates a breaking change in the commit message footer.
     pub const BREAKING_CHANGE_MARKER: &str = "!";
@@ -296,4 +292,3 @@ pub mod changelog {
         }
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,18 @@
+//! # mkcmt.lib
+//!
+//! This library provides functionality to parse conventional commit messages and
+//! exposes changelog metadata. The expected commit message format is:
+//!
+//! ```text
+//! <type>(<optional scope>): <description>
+//!
+//! <optional body>
+//!
+//! <optional footer>
+//! ```
+//!
+//! Use the modules provided to parse commit messages or retrieve changelog data.
+
+pub mod commit;
+pub mod changelog;
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,5 @@
 //!
 //! Use the modules provided to parse commit messages or retrieve changelog data.
 
-pub mod commit;
 pub mod changelog;
-
+pub mod commit;

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,10 @@ fn confirm_user_input(prompt: &str) -> Result<bool, Box<dyn std::error::Error>> 
 }
 
 fn log_output(filename: &str, content: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let mut file = OpenOptions::new().create(true).append(true).open(filename)?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(filename)?;
     writeln!(file, "\n----------------------\n{}\n", content)?;
     Ok(())
 }
@@ -302,7 +305,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     chat_loop(diff_text)
 }
-
 
 // #![doc = include_str!("../README.md")]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,6 @@ compile_error!(
 #[cfg(feature = "uses_tokio_rt")]
 use tokio_rt as tokio;
 
-// For synchronous branch using plain Tokio, we rely on the tokio_plain dependency.
-// (No aliasing is needed since we won't be invoking runtime APIs.)
-
 // Clipboard support via arboard.
 #[cfg(feature = "uses_arboard")]
 use arboard::Clipboard;
@@ -28,6 +25,26 @@ use genai::chat::{ChatMessage, ChatRequest};
 use std::fs::OpenOptions;
 use std::io::{self, Write};
 use std::process::Command;
+
+// --- CLI Argument Parsing ---
+use clap::Parser;
+
+/// mkcmt: A tool for conventional commits and commit message recovery.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Activate recovery mode to restore a previous commit message (from HEAD@{1}).
+    #[arg(short = 'r', long)]
+    recovery: bool,
+
+    /// Perform a soft reset on the current branch.
+    #[arg(short = 's', long = "soft-reset")]
+    soft: bool,
+
+    /// Display the current (last) commit message.
+    #[arg(short = 'c', long = "current")]
+    current: bool,
+}
 
 // --- Common Helper Functions ---
 
@@ -50,10 +67,7 @@ fn confirm_user_input(prompt: &str) -> Result<bool, Box<dyn std::error::Error>> 
 }
 
 fn log_output(filename: &str, content: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(filename)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(filename)?;
     writeln!(file, "\n----------------------\n{}\n", content)?;
     Ok(())
 }
@@ -173,16 +187,90 @@ fn chat_loop(diff_text: String) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+// --- Recovery Mode ---
+
+/// Recovers the commit message from HEAD@{1}, prints it, and prompts the user to copy it to the clipboard.
+///
+/// This function executes `git show -s --format=%B HEAD@{1}` to obtain the commit
+/// message, prints the message to the terminal, and then asks the user if they wish to copy it.
+fn recover_commit_message() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(&["show", "-s", "--format=%B", "HEAD@{1}"])
+        .output()?;
+
+    if !output.status.success() {
+        eprintln!("Error retrieving commit message");
+        std::process::exit(1);
+    }
+
+    let commit_message = String::from_utf8_lossy(&output.stdout);
+    println!("Recovered commit message:\n\n{}", commit_message);
+
+    if confirm_user_input("\nCopy commit message to clipboard? (y/n): ")? {
+        let mut clipboard = Clipboard::new()?;
+        clipboard.set_text(commit_message.to_owned())?;
+        println!("Commit message copied to clipboard.");
+    } else {
+        println!("Commit message not copied.");
+    }
+    Ok(())
+}
+
+// --- New: Soft Reset Mode ---
+
+/// Performs a soft reset on the current branch.
+fn perform_soft_reset() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(&["reset", "--soft", "HEAD~1"])
+        .output()?;
+
+    if !output.status.success() {
+        eprintln!("Error performing soft reset");
+        std::process::exit(1);
+    }
+
+    println!("Soft reset performed on the current branch.");
+    Ok(())
+}
+
+/// Displays the current (last) commit message.
+fn display_last_commit_message() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(&["show", "-s", "--format=%B", "HEAD"])
+        .output()?;
+
+    if !output.status.success() {
+        eprintln!("Error retrieving last commit message");
+        std::process::exit(1);
+    }
+
+    let commit_message = String::from_utf8_lossy(&output.stdout);
+    println!("Last commit message:\n\n{}", commit_message);
+    Ok(())
+}
+
 // --- Main Functions ---
 
-// When using tokio_rt, manually create a runtime and run the async main.
+// When using tokio_rt, parse CLI arguments, check for additional flags, then run the async main.
 #[cfg(feature = "uses_tokio_rt")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    if args.recovery {
+        recover_commit_message()?;
+        return Ok(());
+    } else if args.soft {
+        perform_soft_reset()?;
+        return Ok(());
+    } else if args.current {
+        display_last_commit_message()?;
+        return Ok(());
+    }
+
     let diff_text = get_diff_text()?;
     if diff_text.is_empty() {
         return Ok(());
     }
-    // Create a Tokio runtime from the tokio_rt dependency.
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async_main(diff_text))
 }
@@ -192,12 +280,277 @@ async fn async_main(diff_text: String) -> Result<(), Box<dyn std::error::Error>>
     chat_loop(diff_text).await
 }
 
-// When using tokio_plain, run a synchronous main.
+// When using tokio_plain, parse CLI arguments and check for additional flags, then run synchronously.
 #[cfg(feature = "uses_tokio_plain")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    if args.recovery {
+        recover_commit_message()?;
+        return Ok(());
+    } else if args.soft {
+        perform_soft_reset()?;
+        return Ok(());
+    } else if args.current {
+        display_last_commit_message()?;
+        return Ok(());
+    }
+
     let diff_text = get_diff_text()?;
     if diff_text.is_empty() {
         return Ok(());
     }
     chat_loop(diff_text)
 }
+
+
+// #![doc = include_str!("../README.md")]
+
+// // Prevent both Tokio implementations from being enabled at the same time.
+// #[cfg(all(feature = "uses_tokio_rt", feature = "uses_tokio_plain"))]
+// compile_error!(
+//     "Features 'uses_tokio_rt' and 'uses_tokio_plain' cannot be enabled simultaneously. Please choose one."
+// );
+
+// // --- Conditional Imports ---
+
+// // When using the runtime-enabled Tokio, alias the dependency as `tokio`.
+// #[cfg(feature = "uses_tokio_rt")]
+// use tokio_rt as tokio;
+
+// // Clipboard support via arboard.
+// #[cfg(feature = "uses_arboard")]
+// use arboard::Clipboard;
+
+// // Async chat functionality via GenAI is only available with tokio_rt.
+// #[cfg(all(feature = "uses_tokio_rt", feature = "uses_genai"))]
+// use genai::Client;
+// #[cfg(all(feature = "uses_tokio_rt", feature = "uses_genai"))]
+// use genai::chat::{ChatMessage, ChatRequest};
+
+// use std::fs::OpenOptions;
+// use std::io::{self, Write};
+// use std::process::Command;
+
+// // --- CLI Argument Parsing ---
+// use clap::Parser;
+
+// /// mkcmt: A tool for conventional commits and commit message recovery.
+// #[derive(Parser, Debug)]
+// #[command(author, version, about, long_about = None)]
+// struct Args {
+//     /// Activate recovery mode to restore a previous commit message.
+//     #[arg(short, long)]
+//     recovery: bool,
+// }
+
+// // --- Common Helper Functions ---
+
+// fn run_git_diff(args: &str) -> Result<String, Box<dyn std::error::Error>> {
+//     let args_vec: Vec<&str> = if args.is_empty() {
+//         vec!["diff"]
+//     } else {
+//         vec!["diff", args]
+//     };
+//     let output = Command::new("git").args(&args_vec).output()?;
+//     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+// }
+
+// fn confirm_user_input(prompt: &str) -> Result<bool, Box<dyn std::error::Error>> {
+//     print!("{}", prompt);
+//     io::stdout().flush()?;
+//     let mut input = String::new();
+//     io::stdin().read_line(&mut input)?;
+//     Ok(input.trim().eq_ignore_ascii_case("y"))
+// }
+
+// fn log_output(filename: &str, content: &str) -> Result<(), Box<dyn std::error::Error>> {
+//     let mut file = OpenOptions::new()
+//         .create(true)
+//         .append(true)
+//         .open(filename)?;
+//     writeln!(file, "\n----------------------\n{}\n", content)?;
+//     Ok(())
+// }
+
+// /// Gather the Git diff text.
+// fn get_diff_text() -> Result<String, Box<dyn std::error::Error>> {
+//     let staged_diff_text = run_git_diff("--cached")?;
+//     let unstaged_diff_text = run_git_diff("")?;
+
+//     let diff_text = if staged_diff_text.is_empty() {
+//         if unstaged_diff_text.is_empty() {
+//             println!("No staged or unstaged changes detected. Exiting.");
+//             return Ok(String::new());
+//         } else {
+//             unstaged_diff_text
+//         }
+//     } else if !unstaged_diff_text.is_empty() {
+//         println!("Both staged and unstaged changes detected.");
+//         if confirm_user_input(
+//             "Include both staged and unstaged changes in commit message? (y/n): ",
+//         )? {
+//             format!("{}\n{}", staged_diff_text, unstaged_diff_text)
+//         } else {
+//             staged_diff_text
+//         }
+//     } else {
+//         staged_diff_text
+//     };
+
+//     Ok(diff_text)
+// }
+
+// // --- Chat Loop Implementations ---
+
+// // Asynchronous chat loop when using tokio_rt and GenAI.
+// #[cfg(all(feature = "uses_tokio_rt", feature = "uses_genai"))]
+// async fn chat_loop(diff_text: String) -> Result<(), Box<dyn std::error::Error>> {
+//     let prompt_template =
+//         "Generate a conventional commit message referencing changed files:\n\n<GIT_DIFF>";
+//     let model = "gpt-4o-mini";
+//     let client = Client::default();
+//     let original_diff_text = diff_text.clone();
+
+//     loop {
+//         let actual_prompt = prompt_template.replace("<GIT_DIFF>", &original_diff_text);
+
+//         let chat_req = ChatRequest::new(vec![
+//             ChatMessage::system(
+//                 "Provide a concise conventional commit message without markdown formatting.",
+//             ),
+//             ChatMessage::user(&actual_prompt),
+//         ]);
+
+//         println!("\nQuerying ChatGPT for commit message...");
+//         let chat_res = client.exec_chat(model, chat_req, None).await?;
+//         let commit_message = chat_res
+//             .content_text_as_str()
+//             .unwrap_or("No response.")
+//             .replace('`', "");
+
+//         log_output("output_cc_suggestions.txt", &commit_message)?;
+//         println!("\nSuggested commit message:\n{}", commit_message);
+
+//         if confirm_user_input("\nAccept this commit message? (y/n): ")? {
+//             if confirm_user_input("\nCopy commit message to clipboard? (y/n): ")? {
+//                 #[cfg(feature = "uses_arboard")]
+//                 {
+//                     let mut clipboard = Clipboard::new()?;
+//                     clipboard.set_text(commit_message.to_owned())?;
+//                     println!("Commit message copied to clipboard.");
+//                 }
+//                 #[cfg(not(feature = "uses_arboard"))]
+//                 {
+//                     println!(
+//                         "Clipboard functionality not enabled (feature 'uses_arboard' is off)."
+//                     );
+//                 }
+//             } else {
+//                 println!("Commit message not copied.");
+//             }
+//             break;
+//         } else {
+//             println!("Refining prompt for a better commit message...");
+//             let refinement_req = ChatRequest::new(vec![
+//                 ChatMessage::system(
+//                     "Suggest an improved prompt to obtain a better conventional commit message following conventional commit specifications.",
+//                 ),
+//                 ChatMessage::user(&actual_prompt),
+//             ]);
+
+//             let refinement_res = client.exec_chat(model, refinement_req, None).await?;
+//             let refined_prompt_template = refinement_res
+//                 .content_text_as_str()
+//                 .unwrap_or(prompt_template)
+//                 .replace("<GIT_DIFF>", &original_diff_text);
+
+//             log_output("output_cc_prompts.txt", &refined_prompt_template)?;
+//             println!("\nRefined prompt used:\n{}", refined_prompt_template);
+//         }
+//     }
+
+//     Ok(())
+// }
+
+// // Asynchronous stub when using tokio_rt but GenAI is disabled.
+// #[cfg(all(feature = "uses_tokio_rt", not(feature = "uses_genai")))]
+// async fn chat_loop(_diff_text: String) -> Result<(), Box<dyn std::error::Error>> {
+//     println!("Async chat functionality is disabled because the 'uses_genai' feature is off.");
+//     Ok(())
+// }
+
+// // Synchronous chat loop when using the plain Tokio dependency.
+// #[cfg(feature = "uses_tokio_plain")]
+// fn chat_loop(diff_text: String) -> Result<(), Box<dyn std::error::Error>> {
+//     println!("Diff text:\n{}", diff_text);
+//     println!("Async chat functionality is disabled (using tokio_plain).");
+//     Ok(())
+// }
+
+// // --- Recovery Mode ---
+
+// /// Recovers the commit message from HEAD@{1}, prints it, and prompts the user to copy it to the clipboard.
+// ///
+// /// This function executes `git show -s --format=%B HEAD@{1}` to obtain the commit
+// /// message, prints the message to the terminal, and then asks the user if they wish to copy it.
+// fn recover_commit_message() -> Result<(), Box<dyn std::error::Error>> {
+//     let output = Command::new("git")
+//         .args(&["show", "-s", "--format=%B", "HEAD@{1}"])
+//         .output()?;
+
+//     if !output.status.success() {
+//         eprintln!("Error retrieving commit message");
+//         std::process::exit(1);
+//     }
+
+//     let commit_message = String::from_utf8_lossy(&output.stdout);
+//     println!("Recovered commit message:\n\n{}", commit_message);
+
+//     if confirm_user_input("\nCopy commit message to clipboard? (y/n): ")? {
+//         let mut clipboard = Clipboard::new()?;
+//         clipboard.set_text(commit_message.to_owned())?;
+//         println!("Commit message copied to clipboard.");
+//     } else {
+//         println!("Commit message not copied.");
+//     }
+//     Ok(())
+// }
+
+// // --- Main Functions ---
+
+// // When using tokio_rt, parse CLI arguments, check for recovery mode, then run the async main.
+// #[cfg(feature = "uses_tokio_rt")]
+// fn main() -> Result<(), Box<dyn std::error::Error>> {
+//     let args = Args::parse();
+//     if args.recovery {
+//         recover_commit_message()?;
+//         return Ok(());
+//     }
+//     let diff_text = get_diff_text()?;
+//     if diff_text.is_empty() {
+//         return Ok(());
+//     }
+//     let rt = tokio::runtime::Runtime::new()?;
+//     rt.block_on(async_main(diff_text))
+// }
+
+// #[cfg(feature = "uses_tokio_rt")]
+// async fn async_main(diff_text: String) -> Result<(), Box<dyn std::error::Error>> {
+//     chat_loop(diff_text).await
+// }
+
+// // When using tokio_plain, parse CLI arguments and check for recovery mode, then run synchronously.
+// #[cfg(feature = "uses_tokio_plain")]
+// fn main() -> Result<(), Box<dyn std::error::Error>> {
+//     let args = Args::parse();
+//     if args.recovery {
+//         recover_commit_message()?;
+//         return Ok(());
+//     }
+//     let diff_text = get_diff_text()?;
+//     if diff_text.is_empty() {
+//         return Ok(());
+//     }
+//     chat_loop(diff_text)
+// }

--- a/tests/integration_tests_commit.rs
+++ b/tests/integration_tests_commit.rs
@@ -1,0 +1,31 @@
+
+use mkcmt::commit::CommitMessage;
+
+#[test]
+fn test_parse_breaking_change_with_proper_formatting() {
+    // This input uses proper blank lines so that the parser splits the input into header, body, and footer.
+    let input = r#"feat(ui): add new button
+
+This commit adds a new button to the UI.
+
+BREAKING CHANGE!: The button API has changed."#;
+    
+    let commit = CommitMessage::parse(input).expect("Failed to parse commit message");
+    assert_eq!(commit.commit_type, "feat");
+    assert_eq!(commit.scope, Some("ui".into()));
+    assert_eq!(commit.description, "add new button");
+    // With correct formatting, the footer is recognized and the breaking flag is set.
+    assert!(commit.breaking, "Commit should be marked as breaking");
+}
+
+#[test]
+fn test_parse_no_breaking_change_with_single_newlines() {
+    // This input uses single newlines; the parser treats the entire input as a single section (header only)
+    // so no footer is detected and breaking remains false.
+    let input = "feat(ui): add new button\nThis commit adds a new button to the UI.\nBREAKING CHANGE!: The button API has changed.";
+    
+    let commit = CommitMessage::parse(input).expect("Failed to parse commit message");
+    // Without the proper blank lines, no footer is parsed, so breaking should be false.
+    assert!(!commit.breaking, "Commit should not be marked as breaking");
+}
+

--- a/tests/integration_tests_commit.rs
+++ b/tests/integration_tests_commit.rs
@@ -1,4 +1,3 @@
-
 use mkcmt::commit::CommitMessage;
 
 #[test]
@@ -9,7 +8,7 @@ fn test_parse_breaking_change_with_proper_formatting() {
 This commit adds a new button to the UI.
 
 BREAKING CHANGE!: The button API has changed."#;
-    
+
     let commit = CommitMessage::parse(input).expect("Failed to parse commit message");
     assert_eq!(commit.commit_type, "feat");
     assert_eq!(commit.scope, Some("ui".into()));
@@ -23,9 +22,8 @@ fn test_parse_no_breaking_change_with_single_newlines() {
     // This input uses single newlines; the parser treats the entire input as a single section (header only)
     // so no footer is detected and breaking remains false.
     let input = "feat(ui): add new button\nThis commit adds a new button to the UI.\nBREAKING CHANGE!: The button API has changed.";
-    
+
     let commit = CommitMessage::parse(input).expect("Failed to parse commit message");
     // Without the proper blank lines, no footer is parsed, so breaking should be false.
     assert!(!commit.breaking, "Commit should not be marked as breaking");
 }
-


### PR DESCRIPTION
## [0.2.2](https://github.com/davehorner/mkcmt/compare/v0.2.1...v0.2.2) - 2025-03-12

docs(qc): update README.md addressing version inconsistencies and run HORNERs qc (fmt, fix, audit)

- Updated the README.md to resolve version inconsistencies.
- Executed HORNERs qc with fmt, fix, and audit options to ensure code quality.

## [0.2.1](https://github.com/davehorner/mkcmt/compare/v0.2.0...v0.2.1) - 2025-03-12

### Added

feat(mode_current, mode_recovery, mode_softreset, tests): implement comprehensive branch management enhancements with soft reset (-s), current commit retrieval (-c), and advanced recovery mode integration

- Introduced the -s flag to perform a soft reset on the current branch, preserving uncommitted changes.
- Added the -c flag to retrieve and display the current last commit message for quick reference.
- Enhanced recovery mode to seamlessly restore previous commit messages from HEAD@{1}.
- Developed extensive integration tests to ensure robust functionality across all branch management modes.
- Begin code for parsing commits and CHANGELOGs